### PR TITLE
[Multi] Fix segmentId continuity across ASR restarts

### DIFF
--- a/Scheduler/components/BrokerClient/index.js
+++ b/Scheduler/components/BrokerClient/index.js
@@ -221,19 +221,22 @@ class BrokerClient extends Component {
   async saveTranscription(transcription, sessionId, channelId) {
     try {
       const newTranscription = JSON.stringify([transcription]);
-      await Model.Channel.update(
-        {
-          closedCaptions: Model.sequelize.literal(
-            `COALESCE("closedCaptions"::jsonb, '[]'::jsonb) || ${Model.sequelize.escape(newTranscription)}::jsonb`
-          )
-        },
-        {
-          where: {
-            sessionId: sessionId,
-            id: channelId
-          }
+      const updateFields = {
+        closedCaptions: Model.sequelize.literal(
+          `COALESCE("closedCaptions"::jsonb, '[]'::jsonb) || ${Model.sequelize.escape(newTranscription)}::jsonb`
+        )
+      };
+      if (transcription.segmentId !== undefined) {
+        updateFields.lastSegmentId = Model.sequelize.literal(
+          `GREATEST(COALESCE("lastSegmentId", 0), ${parseInt(transcription.segmentId, 10) || 0})`
+        );
+      }
+      await Model.Channel.update(updateFields, {
+        where: {
+          sessionId: sessionId,
+          id: channelId
         }
-      );
+      });
     } catch (err) {
       logger.error(
         `${new Date().toISOString()} [TRANSCRIPTION_SAVE_ERROR]: ${err.message}`,
@@ -429,7 +432,7 @@ class BrokerClient extends Component {
         {
           model: Model.Channel,
           as: 'channels',
-          attributes: ['id', 'translations', 'streamEndpoints', 'streamStatus', 'diarization', 'keepAudio', 'compressAudio', 'enableLiveTranscripts'],
+          attributes: ['id', 'translations', 'streamEndpoints', 'streamStatus', 'diarization', 'keepAudio', 'compressAudio', 'enableLiveTranscripts', 'lastSegmentId'],
           include: [{
             model: Model.TranscriberProfile,
             attributes: ['config'],

--- a/Session-API/components/BrokerClient/index.js
+++ b/Session-API/components/BrokerClient/index.js
@@ -39,7 +39,7 @@ class BrokerClient extends Component {
         {
           model: Model.Channel,
           as: 'channels',
-          attributes: ['id', 'translations', 'streamEndpoints', 'streamStatus', 'diarization', 'keepAudio', 'compressAudio', 'enableLiveTranscripts'],
+          attributes: ['id', 'translations', 'streamEndpoints', 'streamStatus', 'diarization', 'keepAudio', 'compressAudio', 'enableLiveTranscripts', 'lastSegmentId'],
           include: [{
             model: Model.TranscriberProfile,
             attributes: ['config'],

--- a/Transcriber/ASR/index.js
+++ b/Transcriber/ASR/index.js
@@ -27,14 +27,14 @@ class ASR extends eventEmitter {
     TRANSCRIBING: 'transcribing'
   };
 
-  constructor(session, channel) {
+  constructor(session, channel, options = {}) {
     super();
     this.session = session;
     this.channel = channel;
     this.logger = logger.getChannelLogger(this.session.id, this.channel.id);
     this.provider = null;
     this.state = ASR.states.CLOSED;
-    this.segmentId = 1;
+    this.segmentId = options.initialSegmentId || 1;
     this._dualFinalCount = 0;
     this.init();
   }

--- a/Transcriber/components/StreamingServer/index.js
+++ b/Transcriber/components/StreamingServer/index.js
@@ -28,6 +28,7 @@ class StreamingServer extends Component {
     this.state = StreamingServer.states.CLOSED;
     this.ASRs = new Map();
     this.bots = new Map();
+    this.lastSegmentIds = new Map();
     this.servers = [];
     this.init().then(async () => {
       // intialize the streaming servers
@@ -52,7 +53,8 @@ class StreamingServer extends Component {
 
       server.on('session-start', (session, channel) => {
         try {
-          const asr = new ASR(session, channel);
+          const initialSegmentId = this.resolveInitialSegmentId(session.id, channel.id, channel);
+          const asr = new ASR(session, channel, { initialSegmentId });
           asr.on('partial', (transcription) => {
             this.emit('partial', transcription, session.id, channel.id, channel);
           });
@@ -74,6 +76,8 @@ class StreamingServer extends Component {
           if (!asr) {
             return;
           }
+
+          this.preserveSegmentId(session.id, channelId, asr);
 
           // store in a final with the bot the session-stop
           asr.streamStopped();
@@ -118,7 +122,8 @@ class StreamingServer extends Component {
       bot.on('session-start', (session, channel) => {
         logger.info(`Session ${session.id}, channel ${channel.id} started`);
 
-        const asr = new ASR(session, channel);
+        const initialSegmentId = this.resolveInitialSegmentId(session.id, channel.id, channel);
+        const asr = new ASR(session, channel, { initialSegmentId });
         asr.on('partial', (transcription) => {
           let subtitle = transcription.text;
           if (subSource && transcription.translations) {
@@ -228,6 +233,8 @@ class StreamingServer extends Component {
       // Also stop and remove the associated ASR instance if it exists
       const asr = this.ASRs.get(botKey);
       if (asr) {
+        this.preserveSegmentId(sessionId, channelId, asr);
+        asr.streamStopped();
         asr.removeAllListeners();
         asr.dispose();
         this.ASRs.delete(botKey);
@@ -238,6 +245,18 @@ class StreamingServer extends Component {
     } catch (error) {
       logger.error(`Error stopping bot: ${error.message}`);
     }
+  }
+
+  resolveInitialSegmentId(sessionId, channelId, channel) {
+    const key = `${sessionId}_${channelId}`;
+    const memorySegmentId = this.lastSegmentIds.get(key);
+    const mqttSegmentId = channel.lastSegmentId;
+    return memorySegmentId || (mqttSegmentId ? mqttSegmentId + 1 : 1);
+  }
+
+  preserveSegmentId(sessionId, channelId, asr) {
+    const key = `${sessionId}_${channelId}`;
+    this.lastSegmentIds.set(key, asr.segmentId + 1);
   }
 
   async startServers() {

--- a/lib/model/model.js
+++ b/lib/model/model.js
@@ -151,6 +151,11 @@ const Channel = sequelize.define('channel', {
         allowNull: true,
         defaultValue: null
     },
+    lastSegmentId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        defaultValue: 0
+    },
     closedCaptions: {
         type: DataTypes.JSONB,
         allowNull: true

--- a/migration/migrations/20260324130000-add-last-segment-id.js
+++ b/migration/migrations/20260324130000-add-last-segment-id.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('channels', 'lastSegmentId', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('channels', 'lastSegmentId');
+  },
+};


### PR DESCRIPTION
Preserve segmentId when an ASR instance is stopped and restarted within the same session, preventing duplicate segment numbering. The last segmentId is tracked in-memory (StreamingServer.lastSegmentIds) and persisted to the database (channels.lastSegmentId) so it survives both intra-process restarts and full transcriber failovers.