### PR TITLE
feat: Google Cloud Speech-to-Text ASR provider

### DIFF
--- a/Session-API/components/WebServer/routes/api-docs/swagger/api/transcriber_profiles.json
+++ b/Session-API/components/WebServer/routes/api-docs/swagger/api/transcriber_profiles.json
@@ -46,12 +46,29 @@
         "transcriber_profiles"
       ],
       "summary": "Create a new transcriber config",
-      "description": "For Amazon profiles, use **multipart/form-data** to upload certificate (.crt) and privateKey (.pem) files. The private key **must** be in PKCS#8 format (BEGIN PRIVATE KEY or BEGIN ENCRYPTED PRIVATE KEY). Traditional RSA format (BEGIN RSA PRIVATE KEY) is **not supported** - convert using: `openssl pkcs8 -topk8 -in old.pem -out new.pem`. For other profiles (Microsoft, LinTO), use application/json.",
+      "description": "For Amazon profiles, use **multipart/form-data** to upload certificate (.crt) and privateKey (.pem) files. The private key **must** be in PKCS#8 format (BEGIN PRIVATE KEY or BEGIN ENCRYPTED PRIVATE KEY). Traditional RSA format (BEGIN RSA PRIVATE KEY) is **not supported** - convert using: `openssl pkcs8 -topk8 -in old.pem -out new.pem`. For other profiles (Microsoft, LinTO, Google), use application/json.\n\n**Google** (Cloud Speech-to-Text): authenticate with a Google Cloud **service-account key**. Paste the full service-account JSON into `config.credentials` (stored encrypted, returned obfuscated as `Secret credentials are hidden`). Optional `config.model` (`latest_long` | `latest_short` | `telephony`, empty = Google default) and `config.projectId` (defaults to the key's `project_id`). Languages use BCP-47 codes (e.g. `fr-FR`); up to 3 extra candidates act as alternate languages. Google runs in real-time `StreamingRecognize`, which has **no native translation** (use the external translators downstream). Diarization capability is carried in the profile (`config.hasDiarization`); no server env var is required.",
       "requestBody": {
         "content": {
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/TranscriberProfileRequest"
+            },
+            "examples": {
+              "google": {
+                "summary": "Google Cloud Speech-to-Text profile",
+                "value": {
+                  "config": {
+                    "type": "google",
+                    "name": "Google FR",
+                    "description": "Google STT (French, English fallback)",
+                    "languages": [{ "candidate": "fr-FR" }, { "candidate": "en-US" }],
+                    "credentials": "{\"type\":\"service_account\",\"project_id\":\"my-gcp-project\",\"private_key\":\"-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n\",\"client_email\":\"stt@my-gcp-project.iam.gserviceaccount.com\"}",
+                    "model": "latest_long",
+                    "hasDiarization": false
+                  },
+                  "quickMeeting": false
+                }
+              }
             }
           },
           "multipart/form-data": {
@@ -126,7 +143,7 @@
         "transcriber_profiles"
       ],
       "summary": "Update a transcriber config by ID (partial update)",
-      "description": "Updates a transcriber profile with partial data. Only fields provided in the request body will be updated. The config field is merged with the existing configuration. For Amazon profiles, use **multipart/form-data** to update certificate (.crt) and/or privateKey (.pem) files. Private keys **must** be in PKCS#8 format - convert if needed: `openssl pkcs8 -topk8 -in old.pem -out new.pem`.",
+      "description": "Updates a transcriber profile with partial data. Only fields provided in the request body will be updated. The config field is merged with the existing configuration. For Amazon profiles, use **multipart/form-data** to update certificate (.crt) and/or privateKey (.pem) files. Private keys **must** be in PKCS#8 format - convert if needed: `openssl pkcs8 -topk8 -in old.pem -out new.pem`. For **Google** profiles, omit `config.credentials` to keep the stored service-account key, or send a new full service-account JSON to replace it.",
       "parameters": [
         {
           "name": "id",

--- a/Session-API/components/WebServer/routes/api-docs/swagger/components/schemas/transcriber_profiles.json
+++ b/Session-API/components/WebServer/routes/api-docs/swagger/components/schemas/transcriber_profiles.json
@@ -86,7 +86,8 @@
           "enum": [
             "microsoft",
             "linto",
-            "amazon"
+            "amazon",
+            "google"
           ]
         },
         "name": {
@@ -142,7 +143,7 @@
         },
         "credentials": {
           "type": "string",
-          "description": "Auto-generated encrypted bundle containing certificate, private key, and passphrase (read-only, set by server)"
+          "description": "For amazon: auto-generated encrypted bundle (certificate, private key, passphrase). For google: the full Google service-account JSON key text (plaintext on input, stored encrypted, returned obfuscated). Set/encrypted by the server."
         },
         "trustAnchorArn": {
           "type": "string",
@@ -155,6 +156,14 @@
         "roleArn": {
           "type": "string",
           "description": "AWS IAM Role ARN to assume"
+        },
+        "model": {
+          "type": "string",
+          "description": "Google STT model (empty/absent => Google default): \"latest_long\", \"latest_short\", or \"telephony\""
+        },
+        "projectId": {
+          "type": "string",
+          "description": "Google Cloud project ID override (falls back to project_id from the service-account credentials)"
         }
       },
       "oneOf": [
@@ -207,7 +216,8 @@
           "enum": [
             "microsoft",
             "linto",
-            "amazon"
+            "amazon",
+            "google"
           ]
         },
         "name": {
@@ -262,7 +272,7 @@
         },
         "credentials": {
           "type": "string",
-          "description": "Auto-generated encrypted bundle containing certificate, private key, and passphrase (read-only, set by server)"
+          "description": "For amazon: auto-generated encrypted bundle (certificate, private key, passphrase). For google: the full Google service-account JSON key text (plaintext on input, stored encrypted, returned obfuscated). Set/encrypted by the server."
         },
         "trustAnchorArn": {
           "type": "string",
@@ -275,6 +285,14 @@
         "roleArn": {
           "type": "string",
           "description": "AWS IAM Role ARN to assume"
+        },
+        "model": {
+          "type": "string",
+          "description": "Google STT model (empty/absent => Google default): \"latest_long\", \"latest_short\", or \"telephony\""
+        },
+        "projectId": {
+          "type": "string",
+          "description": "Google Cloud project ID override (falls back to project_id from the service-account credentials)"
         }
       }
     }

--- a/Session-API/components/WebServer/routes/api/transcriber_profiles.js
+++ b/Session-API/components/WebServer/routes/api/transcriber_profiles.js
@@ -25,6 +25,9 @@ const validateTranscriberProfile = (body, update=false) => {
         // certificate and privateKey will be validated in the route handler after file upload
         return;
     }
+    if (config.type === 'google' && (!config.languages.every(lang => isValidLocale(lang.candidate)) || (!config.credentials && !update))) {
+        return { error: 'Invalid Google TranscriberProfile languages or missing credentials', status: 400 };
+    }
     if (config.type === 'openai_streaming') {
         if (!config.endpoint || !config.model) {
             return { error: 'OpenAI Streaming profiles require endpoint and model', status: 400 };
@@ -124,6 +127,11 @@ const extendTranscriberProfile = (body) => {
     const diarizationEnv = process.env[`ASR_HAS_DIARIZATION_${config.type.toUpperCase()}`];
     if (diarizationEnv) {
         body.config.hasDiarization = diarizationEnv.toUpperCase() == 'TRUE';
+    }
+    else if (config.type === 'google') {
+        // Google profiles are fully self-contained: the diarization capability is
+        // carried in the profile itself (no deployment env var required).
+        body.config.hasDiarization = config.hasDiarization === true;
     }
     else {
         body.config.hasDiarization = false;

--- a/Transcriber/ASR/google/index.js
+++ b/Transcriber/ASR/google/index.js
@@ -1,0 +1,184 @@
+const speech = require('@google-cloud/speech');
+const { Security } = require('live-srt-lib');
+const logger = require('../../logger');
+const EventEmitter = require('eventemitter3');
+
+// Google v1 streamingRecognize has a ~5 min hard limit per stream; restart proactively.
+const STREAM_RESTART_MS = 240000; // 4 min
+
+class GoogleTranscriber extends EventEmitter {
+    static ERROR_MAP = {
+        3: 'BAD_REQUEST_PARAMETERS',   // INVALID_ARGUMENT
+        4: 'SERVICE_TIMEOUT',          // DEADLINE_EXCEEDED
+        7: 'FORBIDDEN',                // PERMISSION_DENIED
+        8: 'TOO_MANY_REQUESTS',        // RESOURCE_EXHAUSTED
+        13: 'SERVICE_ERROR',           // INTERNAL
+        14: 'CONNECTION_FAILURE',      // UNAVAILABLE
+        16: 'AUTHENTICATION_FAILURE',  // UNAUTHENTICATED
+    };
+
+    constructor(session, channel) {
+        super();
+        this.session = session;
+        this.channel = channel;
+        this.logger = logger.getChannelLogger(session.id, channel.id);
+        this.client = null;
+        this.recognizeStream = null;
+        this.isStreaming = false;
+        this.restartTimer = null;
+        this.lastPartial = null;
+        this.lastEnd = 0;
+        this._streamOffset = 0; // seconds accumulated across stream restarts (monotonic timestamps)
+        this.startedAt = null;
+        this.emit('closed');
+    }
+
+    _parseCredentials() {
+        const { config } = this.channel.transcriberProfile;
+        if (!config.credentials) throw new Error('Google ASR: missing credentials');
+        const decrypted = new Security().safeDecrypt(config.credentials);
+        try { return JSON.parse(decrypted); }
+        catch (e) { throw new Error('Google ASR: invalid service-account JSON: ' + e.message); }
+    }
+
+    _buildRequest() {
+        const { config } = this.channel.transcriberProfile;
+        const langs = config.languages.map(l => l.candidate);
+        const recognitionConfig = {
+            encoding: 'LINEAR16',
+            sampleRateHertz: 16000,
+            audioChannelCount: 1,
+            languageCode: langs[0],
+            enableAutomaticPunctuation: true,
+        };
+        const alternates = langs.slice(1, 4); // Google allows up to 3 alternates
+        if (alternates.length > 0) recognitionConfig.alternativeLanguageCodes = alternates;
+        if (config.model) recognitionConfig.model = config.model;
+        if (this.channel.diarization) {
+            recognitionConfig.diarizationConfig = {
+                enableSpeakerDiarization: true,
+                minSpeakerCount: 1,
+                maxSpeakerCount: 6,
+            };
+        }
+        return { config: recognitionConfig, interimResults: true };
+    }
+
+    formatResult(result) {
+        const alt = (result.alternatives && result.alternatives[0]) || {};
+        const text = alt.transcript || '';
+        const ret = result.resultEndTime || {};
+        const rel = Number(ret.seconds || 0) + Number(ret.nanos || 0) / 1e9;
+        const end = this._streamOffset + rel;
+        let locutor = null;
+        if (this.channel.diarization && Array.isArray(alt.words) && alt.words.length) {
+            const tagged = alt.words.filter(w => w.speakerTag);
+            if (tagged.length) locutor = 'spk_' + tagged[tagged.length - 1].speakerTag;
+        }
+        const lang = result.languageCode || this.channel.transcriberProfile.config.languages[0].candidate;
+        return { astart: this.startedAt, text, translations: {}, start: this.lastEnd, end, lang, locutor };
+    }
+
+    _startStream() {
+        const request = this._buildRequest();
+        this.recognizeStream = this.client
+            .streamingRecognize(request)
+            .on('error', (err) => this._onError(err))
+            .on('data', (data) => this._onData(data));
+        this.restartTimer = setTimeout(() => this._restartStream(), STREAM_RESTART_MS);
+    }
+
+    _restartStream() {
+        if (!this.isStreaming) return;
+        if (this.restartTimer) { clearTimeout(this.restartTimer); this.restartTimer = null; }
+        this._streamOffset = this.lastEnd; // continue timestamps from where we stopped
+        const old = this.recognizeStream;
+        this.recognizeStream = null;
+        if (old) { try { old.removeAllListeners('error'); old.end(); } catch (e) {} }
+        this.logger.info('Google ASR: restarting stream (duration limit)');
+        this._startStream();
+    }
+
+    _onError(err) {
+        // OUT_OF_RANGE(11): stream exceeded max duration -> restart silently
+        if (err && (err.code === 11 || /exceed/i.test(err.message || ''))) {
+            this.logger.warn('Google ASR: stream duration exceeded, restarting');
+            this._restartStream();
+            return;
+        }
+        if (!this.isStreaming) return;
+        this.logger.error('Google ASR error: ' + err.message + ' (code ' + err.code + ')');
+        this.emit('error', GoogleTranscriber.ERROR_MAP[err.code] || 'RUNTIME_ERROR');
+    }
+
+    _onData(data) {
+        if (!data.results || !data.results.length) return;
+        const result = data.results[0];
+        if (!result.alternatives || !result.alternatives.length) return;
+        const payload = this.formatResult(result);
+        if (!payload.text || payload.text.trim().length === 0) return;
+        if (result.isFinal) {
+            this.lastEnd = payload.end;
+            this.lastPartial = null;
+            this.emit('transcribed', payload);
+        } else {
+            this.lastPartial = payload;
+            this.emit('transcribing', payload);
+        }
+    }
+
+    async start() {
+        this.startedAt = new Date().toISOString();
+        this.lastEnd = 0;
+        this._streamOffset = 0;
+        this.lastPartial = null;
+        this.emit('connecting');
+        try {
+            const creds = this._parseCredentials();
+            const { config } = this.channel.transcriberProfile;
+            this.client = new speech.SpeechClient({
+                projectId: config.projectId || creds.project_id,
+                credentials: { client_email: creds.client_email, private_key: creds.private_key },
+            });
+            this.isStreaming = true;
+            this._startStream();
+            this.emit('ready');
+            this.logger.info('Google ASR started (lang=' + config.languages[0].candidate + ', diarization=' + !!this.channel.diarization + ')');
+        } catch (err) {
+            this.logger.error('Google ASR failed to start: ' + err.message);
+            this.emit('error', GoogleTranscriber.ERROR_MAP[err.code] || 'RUNTIME_ERROR');
+            this.isStreaming = false;
+        }
+    }
+
+    transcribe(buffer) {
+        if (this.isStreaming && this.recognizeStream && this.recognizeStream.writable) {
+            // CircularBuffer yields a Uint8Array; the gRPC stream expects a Node Buffer.
+            const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
+            try { this.recognizeStream.write(buf); }
+            catch (err) { this.logger.warn('Google ASR: write failed: ' + err.message); }
+        } else if (!this._warnThrottled) {
+            this._warnThrottled = true;
+            this.logger.warn('Google ASR: stream not ready, dropping audio');
+            setTimeout(() => { this._warnThrottled = false; }, 5000);
+        }
+    }
+
+    async stop() {
+        this.logger.info('Google ASR: stopping');
+        this.isStreaming = false;
+        if (this.restartTimer) { clearTimeout(this.restartTimer); this.restartTimer = null; }
+        if (this.lastPartial && this.lastPartial.text && this.lastPartial.text.trim().length) {
+            this.emit('transcribed', this.lastPartial);
+            this.lastPartial = null;
+        }
+        if (this.recognizeStream) {
+            try { this.recognizeStream.removeAllListeners('error'); this.recognizeStream.end(); } catch (e) {}
+            this.recognizeStream = null;
+        }
+        if (this.client) { try { await this.client.close(); } catch (e) {} this.client = null; }
+        this.emit('closed');
+    }
+}
+
+module.exports = GoogleTranscriber;

--- a/Transcriber/package-lock.json
+++ b/Transcriber/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "live-transcription-open-source-toolbox-transcriber",
-  "version": "1.0.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "live-transcription-open-source-toolbox-transcriber",
-      "version": "1.0.0",
+      "version": "1.3.1",
       "license": "EUPL",
       "dependencies": {
         "@aws-sdk/client-transcribe-streaming": "^3.0.0",
+        "@google-cloud/speech": "^6.7.1",
         "eventemitter3": "^5.0.1",
         "fluent-ffmpeg": "^2.1.3",
         "franc": "^6.2.0",
@@ -30,7 +31,7 @@
     },
     "../lib": {
       "name": "live-transcription-open-source-toolbox-library",
-      "version": "1.0.0",
+      "version": "1.3.1",
       "license": "EUPL",
       "dependencies": {
         "dotenv": "^16.4.7",
@@ -779,6 +780,124 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@google-cloud/common": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.2.tgz",
+      "integrity": "sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "arrify": "^2.0.1",
+        "duplexify": "^4.1.1",
+        "extend": "^3.0.2",
+        "google-auth-library": "^9.0.0",
+        "html-entities": "^2.5.2",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.1.0.tgz",
+      "integrity": "sha512-G/FQx5cE/+DqBbOpA5jKsegGwdPniU6PuIEMt+qxWgFxvxuFOzVmp6zYchtYuwAWV5/8Dgs0yAmjvNZv3uXLQg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/speech": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/speech/-/speech-6.7.1.tgz",
+      "integrity": "sha512-KgI2xmO8jHStYyoblj5FQ1G1Lk9JuvsR3wUpNSjxJP89yKA+Y/TBgGFvvu+mwm/f5x2ldLLY4So1VGNXZ+yzKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/common": "^5.0.0",
+        "@types/pumpify": "^1.4.1",
+        "google-gax": "^4.0.3",
+        "pumpify": "^2.0.0",
+        "stream-events": "^1.0.4",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/speech/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -875,6 +994,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -969,6 +1098,63 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
       "version": "2.10.13",
@@ -1641,11 +1827,35 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/duplexify": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.5.tgz",
+      "integrity": "sha512-fB56ACzlW91UdZ5F3VXplVMDngO8QaX5Y2mjvADtN01TT2TMy4WjF0Lg+tFDvt4uMBeTe4SgaD+qCrA7dL5/tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -1656,6 +1866,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -1671,6 +1887,34 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/pumpify": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/pumpify/-/pumpify-1.4.5.tgz",
+      "integrity": "sha512-BGVAQyK5yJdfIII230fVYGY47V63hUNAhryuuS3b4lEN2LNwxUXFKsEf8QLDCjmZuimlj23BHppJgcrGvNtqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/duplexify": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT"
     },
     "node_modules/@types/webrtc": {
       "version": "0.0.37",
@@ -1695,6 +1939,18 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -1790,6 +2046,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/assert": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
@@ -1820,6 +2085,12 @@
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -1948,6 +2219,26 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/basic-auth-connect": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.1.0.tgz",
@@ -1975,6 +2266,15 @@
         "bytesish": "^0.4.1",
         "caseless": "~0.12.0",
         "is-stream": "^2.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/body-parser": {
@@ -2071,6 +2371,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2353,6 +2659,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2541,6 +2859,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2601,11 +2928,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -2687,6 +3035,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2791,6 +3154,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -2871,6 +3243,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/extract-zip": {
@@ -3069,6 +3447,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3125,6 +3520,72 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/generator-function": {
@@ -3270,6 +3731,69 @@
         "node": ">=8"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3299,6 +3823,19 @@
       },
       "engines": {
         "node": ">= 5.9.1"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/has-flag": {
@@ -3339,7 +3876,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3352,9 +3888,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3372,6 +3908,22 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
@@ -3757,6 +4309,36 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/linto-node-srt": {
       "name": "@eyevinn/srt",
       "version": "0.8.3",
@@ -3798,6 +4380,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -3814,6 +4402,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -4279,6 +4873,26 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-gyp": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.3.1.tgz",
@@ -4407,6 +5021,15 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -4728,6 +5351,41 @@
         "node": ">=10"
       }
     },
+    "node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4805,6 +5463,17 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
       }
     },
     "node_modules/puppeteer-core": {
@@ -4916,6 +5585,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -4946,6 +5629,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/reusify": {
@@ -5342,6 +6039,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
     "node_modules/streamx": {
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
@@ -5351,6 +6063,15 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -5430,6 +6151,12 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -5535,6 +6262,63 @@
         "node": ">=10"
       }
     },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/text-decoder": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
@@ -5564,6 +6348,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/trigram-utils": {
       "version": "2.0.1",
@@ -5666,6 +6456,12 @@
         "which-typed-array": "^1.1.2"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -5702,6 +6498,22 @@
       "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.8.tgz",
       "integrity": "sha512-21Yi2GhGntMc671vNBCjiAeEVknXjVRoyu+k+9xOMShu+ZQfpGQwnBqbNz/Sv4GXZ6JmutlPAi2nIJcrymAWuQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "1.3.1",

--- a/Transcriber/package.json
+++ b/Transcriber/package.json
@@ -26,6 +26,7 @@
   "license": "EUPL",
   "dependencies": {
     "@aws-sdk/client-transcribe-streaming": "^3.0.0",
+    "@google-cloud/speech": "^6.7.1",
     "eventemitter3": "^5.0.1",
     "fluent-ffmpeg": "^2.1.3",
     "franc": "^6.2.0",

--- a/Transcriber/tests.js
+++ b/Transcriber/tests.js
@@ -16,6 +16,8 @@ require('./tests/test_asr_flush_finals.js');
 require('./tests/test_security_diag.js');
 require('./tests/test_brokerclient_snapshot.js');
 require('./tests/test_amazon_epoch.js');
+require('./tests/test_google_transcriber.js');
+require('./tests/test_session_api_validation.js');
 
 
 describe('CircularBuffer', () => {

--- a/Transcriber/tests/test_google_transcriber.js
+++ b/Transcriber/tests/test_google_transcriber.js
@@ -1,0 +1,328 @@
+const assert = require('assert');
+const path = require('path');
+const { describe, it, before, after } = require('mocha');
+
+// ---- Mock setup: intercept require() before loading GoogleTranscriber ----
+
+const mockLogger = {
+    info() {}, warn() {}, error() {}, debug() {}, log() {},
+    getChannelLogger() {
+        return { info() {}, warn() {}, error() {}, debug() {}, log() {} };
+    }
+};
+
+class MockSecurity {
+    safeDecrypt(text) {
+        return text && text.startsWith('encrypted:') ? text.replace('encrypted:', '') : text;
+    }
+    encrypt(text) { return `encrypted:${text}`; }
+    decrypt(text) { return text.replace('encrypted:', ''); }
+}
+
+// Fake streamingRecognize stream: records the request, lets the test push
+// 'data'/'error' events, and exposes writable + end()/write() like a duplex.
+class MockRecognizeStream {
+    constructor(request) {
+        this.request = request;
+        this.writable = true;
+        this.writes = [];
+        this._handlers = {};
+        this.ended = false;
+    }
+    on(event, cb) {
+        this._handlers[event] = this._handlers[event] || [];
+        this._handlers[event].push(cb);
+        return this;
+    }
+    removeAllListeners(event) {
+        if (event) delete this._handlers[event]; else this._handlers = {};
+        return this;
+    }
+    write(buf) { this.writes.push(buf); }
+    end() { this.ended = true; this.writable = false; }
+    emit(event, payload) {
+        (this._handlers[event] || []).forEach(cb => cb(payload));
+    }
+}
+
+class MockSpeechClient {
+    constructor(opts) {
+        this.opts = opts;
+        this.lastStream = null;
+    }
+    streamingRecognize(request) {
+        this.lastStream = new MockRecognizeStream(request);
+        return this.lastStream;
+    }
+    async close() { this.closed = true; }
+}
+
+const mockSpeechModule = { SpeechClient: MockSpeechClient };
+
+const Module = require('module');
+
+const liveSrtLibPath = require.resolve('live-srt-lib');
+const googleIndexPath = path.resolve(__dirname, '../ASR/google/index.js');
+const googleLoggerPath = path.resolve(__dirname, '../logger.js');
+
+// '@google-cloud/speech' is an external runtime dependency that may not be
+// installed in the test environment (the parent runs npm install separately).
+// Rather than rely on require.resolve (which would throw when the package is
+// absent and break the whole suite), patch Module._load to return the mock for
+// that exact specifier while the google provider is being required.
+function setupMocks() {
+    const origLoad = Module._load;
+    Module._load = function (request, parent, isMain) {
+        if (request === '@google-cloud/speech') return mockSpeechModule;
+        return origLoad.apply(this, arguments);
+    };
+
+    const origLib = require.cache[liveSrtLibPath];
+    const origLogger = require.cache[googleLoggerPath];
+
+    require.cache[liveSrtLibPath] = {
+        id: liveSrtLibPath, filename: liveSrtLibPath, loaded: true,
+        exports: { Security: MockSecurity, logger: mockLogger, Model: {} }
+    };
+    require.cache[googleLoggerPath] = {
+        id: googleLoggerPath, filename: googleLoggerPath, loaded: true, exports: mockLogger
+    };
+    delete require.cache[googleIndexPath];
+
+    return function teardown() {
+        Module._load = origLoad;
+        if (origLib) require.cache[liveSrtLibPath] = origLib; else delete require.cache[liveSrtLibPath];
+        if (origLogger) require.cache[googleLoggerPath] = origLogger; else delete require.cache[googleLoggerPath];
+        delete require.cache[googleIndexPath];
+    };
+}
+
+// A valid (fake) service-account JSON, stored as the "encrypted" credentials so
+// MockSecurity.safeDecrypt yields back the raw JSON text.
+const FAKE_SA = JSON.stringify({
+    type: 'service_account',
+    project_id: 'proj-from-creds',
+    client_email: 'svc@proj.iam.gserviceaccount.com',
+    private_key: '-----BEGIN PRIVATE KEY-----\nXXX\n-----END PRIVATE KEY-----\n',
+});
+
+function makeChannel(opts = {}) {
+    const languages = opts.languages || [{ candidate: 'en-US' }, { candidate: 'fr-FR' }];
+    return {
+        id: 'channel-1',
+        diarization: !!opts.diarization,
+        transcriberProfile: {
+            config: {
+                type: 'google',
+                credentials: 'encrypted:' + FAKE_SA,
+                languages,
+                model: opts.model || '',
+                projectId: opts.projectId,
+            },
+        },
+    };
+}
+
+describe('GoogleTranscriber', () => {
+    let GoogleTranscriber;
+    let teardown;
+
+    before(() => {
+        teardown = setupMocks();
+        GoogleTranscriber = require('../ASR/google/index.js');
+    });
+
+    after(() => { if (teardown) teardown(); });
+
+    describe('_buildRequest()', () => {
+        it('sets languageCode to the first candidate', () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel());
+            const req = t._buildRequest();
+            assert.strictEqual(req.config.languageCode, 'en-US');
+            assert.strictEqual(req.config.encoding, 'LINEAR16');
+            assert.strictEqual(req.config.sampleRateHertz, 16000);
+            assert.strictEqual(req.config.audioChannelCount, 1);
+            assert.strictEqual(req.interimResults, true);
+        });
+
+        it('lists extra languages under alternativeLanguageCodes (max 3)', () => {
+            const channel = makeChannel({
+                languages: [
+                    { candidate: 'en-US' }, { candidate: 'fr-FR' },
+                    { candidate: 'de-DE' }, { candidate: 'es-ES' }, { candidate: 'it-IT' },
+                ],
+            });
+            const t = new GoogleTranscriber({ id: 's' }, channel);
+            const req = t._buildRequest();
+            assert.deepStrictEqual(req.config.alternativeLanguageCodes, ['fr-FR', 'de-DE', 'es-ES']);
+        });
+
+        it('omits alternativeLanguageCodes for a single language', () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel({ languages: [{ candidate: 'en-US' }] }));
+            const req = t._buildRequest();
+            assert.strictEqual(req.config.alternativeLanguageCodes, undefined);
+        });
+
+        it('omits model when config.model is empty', () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel({ model: '' }));
+            const req = t._buildRequest();
+            assert.strictEqual('model' in req.config, false);
+        });
+
+        it('includes model when config.model is set', () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel({ model: 'latest_long' }));
+            const req = t._buildRequest();
+            assert.strictEqual(req.config.model, 'latest_long');
+        });
+
+        it('adds diarizationConfig only when channel.diarization is true', () => {
+            const off = new GoogleTranscriber({ id: 's' }, makeChannel({ diarization: false }));
+            assert.strictEqual('diarizationConfig' in off._buildRequest().config, false);
+
+            const on = new GoogleTranscriber({ id: 's' }, makeChannel({ diarization: true }));
+            const req = on._buildRequest();
+            assert.ok(req.config.diarizationConfig);
+            assert.strictEqual(req.config.diarizationConfig.enableSpeakerDiarization, true);
+        });
+    });
+
+    describe('formatResult()', () => {
+        it('maps transcript->text, resultEndTime->end, returns translations:{} and astart', () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel());
+            t.startedAt = '2026-06-16T00:00:00.000Z';
+            const result = {
+                alternatives: [{ transcript: 'hello world' }],
+                resultEndTime: { seconds: 2, nanos: 500000000 },
+                languageCode: 'en-US',
+            };
+            const out = t.formatResult(result);
+            assert.strictEqual(out.text, 'hello world');
+            assert.strictEqual(out.end, 2.5);
+            assert.deepStrictEqual(out.translations, {});
+            assert.strictEqual(out.astart, '2026-06-16T00:00:00.000Z');
+            assert.strictEqual(out.lang, 'en-US');
+            assert.strictEqual(out.locutor, null);
+        });
+
+        it('continues end from _streamOffset across restarts', () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel());
+            t._streamOffset = 10;
+            const result = {
+                alternatives: [{ transcript: 'again' }],
+                resultEndTime: { seconds: 3, nanos: 0 },
+            };
+            assert.strictEqual(t.formatResult(result).end, 13);
+        });
+
+        it('extracts locutor from speakerTag when diarization is on', () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel({ diarization: true }));
+            const result = {
+                alternatives: [{
+                    transcript: 'who said this',
+                    words: [
+                        { word: 'who', speakerTag: 1 },
+                        { word: 'said', speakerTag: 2 },
+                    ],
+                }],
+                resultEndTime: { seconds: 1, nanos: 0 },
+            };
+            assert.strictEqual(t.formatResult(result).locutor, 'spk_2');
+        });
+    });
+
+    describe('_onData()', () => {
+        it('emits transcribing for interim results', () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel());
+            t.startedAt = 'x';
+            const events = [];
+            t.on('transcribing', p => events.push(p));
+            t.on('transcribed', () => assert.fail('should not emit transcribed for interim'));
+            t._onData({ results: [{
+                isFinal: false,
+                alternatives: [{ transcript: 'partial text' }],
+                resultEndTime: { seconds: 1, nanos: 0 },
+            }] });
+            assert.strictEqual(events.length, 1);
+            assert.strictEqual(events[0].text, 'partial text');
+            assert.ok(t.lastPartial);
+        });
+
+        it('emits transcribed for isFinal results and clears lastPartial', () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel());
+            t.startedAt = 'x';
+            t.lastPartial = { text: 'stale' };
+            const events = [];
+            t.on('transcribed', p => events.push(p));
+            t._onData({ results: [{
+                isFinal: true,
+                alternatives: [{ transcript: 'final text' }],
+                resultEndTime: { seconds: 4, nanos: 0 },
+            }] });
+            assert.strictEqual(events.length, 1);
+            assert.strictEqual(events[0].text, 'final text');
+            assert.strictEqual(t.lastEnd, 4);
+            assert.strictEqual(t.lastPartial, null);
+        });
+
+        it('ignores empty-text results', () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel());
+            t.startedAt = 'x';
+            let emitted = false;
+            t.on('transcribing', () => { emitted = true; });
+            t.on('transcribed', () => { emitted = true; });
+            t._onData({ results: [{ isFinal: true, alternatives: [{ transcript: '   ' }] }] });
+            assert.strictEqual(emitted, false);
+        });
+    });
+
+    describe('stop()', () => {
+        it('flushes a pending partial as transcribed', async () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel());
+            t.startedAt = 'x';
+            t.lastPartial = { astart: 'x', text: 'pending words', translations: {}, start: 0, end: 1, lang: 'en-US', locutor: null };
+            const finals = [];
+            t.on('transcribed', p => finals.push(p));
+            await t.stop();
+            assert.strictEqual(finals.length, 1);
+            assert.strictEqual(finals[0].text, 'pending words');
+            assert.strictEqual(t.lastPartial, null);
+        });
+
+        it('does not emit when there is no pending partial', async () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel());
+            let emitted = false;
+            t.on('transcribed', () => { emitted = true; });
+            await t.stop();
+            assert.strictEqual(emitted, false);
+        });
+    });
+
+    describe('lifecycle: start() / transcribe()', () => {
+        it('start() builds a client and opens a stream, transcribe() writes to it', async () => {
+            const channel = makeChannel({ projectId: 'override-proj' });
+            const t = new GoogleTranscriber({ id: 's' }, channel);
+            const states = [];
+            t.on('connecting', () => states.push('connecting'));
+            t.on('ready', () => states.push('ready'));
+            await t.start();
+            assert.ok(states.includes('connecting'));
+            assert.ok(states.includes('ready'));
+            assert.ok(t.client instanceof MockSpeechClient);
+            assert.strictEqual(t.client.opts.projectId, 'override-proj');
+            assert.ok(t.recognizeStream);
+
+            const buf = Buffer.from([1, 2, 3, 4]);
+            t.transcribe(buf);
+            assert.strictEqual(t.recognizeStream.writes.length, 1);
+            assert.strictEqual(t.recognizeStream.writes[0], buf);
+            await t.stop();
+        });
+
+        it('falls back to credentials project_id when projectId not set', async () => {
+            const t = new GoogleTranscriber({ id: 's' }, makeChannel());
+            await t.start();
+            assert.strictEqual(t.client.opts.projectId, 'proj-from-creds');
+            await t.stop();
+        });
+    });
+});

--- a/Transcriber/tests/test_session_api_validation.js
+++ b/Transcriber/tests/test_session_api_validation.js
@@ -450,6 +450,75 @@ describe('Session API - Transcriber Profile Validation', function () {
         });
     });
 
+    describe('google profile validation (contract test)', function () {
+
+        // The source uses language-tags' tags.check(); language-tags is not a
+        // dependency of the Transcriber workspace, so we use an equivalent
+        // lightweight BCP-47 check for these contract tests.
+        function isValidLocale(locale) {
+            return typeof locale === 'string' && /^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$/.test(locale);
+        }
+
+        // Replicate the validation logic including the google branch (mirrors source)
+        function validateTranscriberProfile(body, update = false) {
+            const config = body.config;
+            if (!config) {
+                return { error: 'TranscriberProfile object is missing', status: 400 };
+            }
+            if (!config.type || !config.name || !config.description || !config.languages || !config.languages.length) {
+                return { error: 'TranscriberProfile object is missing required properties', status: 400 };
+            }
+            if (config.type === 'google' && (!config.languages.every(lang => isValidLocale(lang.candidate)) || (!config.credentials && !update))) {
+                return { error: 'Invalid Google TranscriberProfile languages or missing credentials', status: 400 };
+            }
+            if (config.languages.some(lang => typeof lang !== 'object')) {
+                return { error: 'Invalid TranscriberProfile languages', status: 400 };
+            }
+            if (config.languages.some(lang => typeof lang.candidate !== 'string' || (lang.endpoint !== undefined && typeof lang.endpoint !== 'string'))) {
+                return { error: 'Invalid TranscriberProfile language properties', status: 400 };
+            }
+        }
+
+        it('should accept valid google profile with languages and credentials', function () {
+            const result = validateTranscriberProfile({
+                config: {
+                    type: 'google',
+                    name: 'Google STT',
+                    description: 'Test',
+                    credentials: '{"type":"service_account","project_id":"p"}',
+                    languages: [{ candidate: 'en-US' }, { candidate: 'fr-FR' }]
+                }
+            });
+            assert.strictEqual(result, undefined, 'Valid google profile should return undefined (no error)');
+        });
+
+        it('should reject google without credentials on create', function () {
+            const result = validateTranscriberProfile({
+                config: {
+                    type: 'google',
+                    name: 'Google STT',
+                    description: 'Test',
+                    languages: [{ candidate: 'en-US' }]
+                }
+            });
+            assert.ok(result);
+            assert.strictEqual(result.status, 400);
+            assert.ok(result.error.includes('credentials'));
+        });
+
+        it('should accept google without credentials on update', function () {
+            const result = validateTranscriberProfile({
+                config: {
+                    type: 'google',
+                    name: 'Google STT',
+                    description: 'Test',
+                    languages: [{ candidate: 'en-US' }]
+                }
+            }, true);
+            assert.strictEqual(result, undefined);
+        });
+    });
+
     // -------------------------------------------------------------------
     // API key encryption/obfuscation contract tests
     // -------------------------------------------------------------------
@@ -561,6 +630,9 @@ describe('Session API - Transcriber Profile Validation', function () {
             const diarizationEnv = process.env[`ASR_HAS_DIARIZATION_${config.type.toUpperCase()}`];
             if (diarizationEnv) {
                 body.config.hasDiarization = diarizationEnv.toUpperCase() == 'TRUE';
+            } else if (config.type === 'google') {
+                // Google profiles are self-contained: capability carried in the profile.
+                body.config.hasDiarization = config.hasDiarization === true;
             } else {
                 body.config.hasDiarization = false;
             }
@@ -616,6 +688,16 @@ describe('Session API - Transcriber Profile Validation', function () {
             assert.strictEqual(result.config.hasDiarization, true);
             // Restore
             process.env.ASR_HAS_DIARIZATION_OPENAI_STREAMING = 'false';
+        });
+
+        it('should derive google hasDiarization from the profile (no env var)', function () {
+            delete process.env.ASR_HAS_DIARIZATION_GOOGLE;
+            const enabled = extendTranscriberProfile({ config: { type: 'google', hasDiarization: true } });
+            assert.strictEqual(enabled.config.hasDiarization, true);
+            const disabled = extendTranscriberProfile({ config: { type: 'google', hasDiarization: false } });
+            assert.strictEqual(disabled.config.hasDiarization, false);
+            const omitted = extendTranscriberProfile({ config: { type: 'google' } });
+            assert.strictEqual(omitted.config.hasDiarization, false);
         });
     });
 });


### PR DESCRIPTION
## Summary
Adds **Google Cloud Speech-to-Text** as a new live ASR provider, end to end on the plugins side (transcriber + Session-API profile management).

Companion frontend PR: `linto-ai/linto-studio` branch `feat/google-asr`.

## What's included
- **`Transcriber/ASR/google/`** — new provider using Google Speech **v1 `streamingRecognize`**:
  - LINEAR16 / 16 kHz / mono, automatic punctuation
  - Multi-language (primary + up to 3 alternate candidates)
  - Optional speaker diarization (`channel.diarization`)
  - Proactive stream restart before the ~5 min gRPC limit + silent restart on `OUT_OF_RANGE`, with monotonic timestamps across restarts
  - Partial-flush on stop, throttled drop-audio warning, gRPC-code → error-string map
  - Auto-discovered by the ASR loader (no registry edit)
- **Session-API** — `google` validation branch (valid BCP-47 languages, credentials required unless update); swagger enum + `credentials`/`model`/`projectId` field docs.
- **Self-contained profiles** — Google's diarization capability is carried in the profile (`config.hasDiarization`); no deployment env var. `availableTranslations` stays `[]` because `StreamingRecognize` has no native translation (external translators apply downstream).
- **Auth** — service-account JSON pasted into `config.credentials`, encrypted once via the existing generic path (no Amazon-style multipart).
- **Docs** — Swagger POST/PUT description + a Google request example.

## Tests
- `Transcriber/tests/test_google_transcriber.js` (16 unit tests, SDK mocked).
- Wired the previously-orphaned `test_session_api_validation.js` into the runner; added Google validation + self-contained-diarization cases.
- Full suite: **193 passing**.

## Notes
- Not yet validated live end to end (needs a real GCP service-account key + audio stream); unit tests mock the SDK.
- `@google-cloud/speech@^6.7.0` added to `Transcriber/package.json` (+ lockfile).
