### PR TITLE
fix(transcriber): keep a constant audio rate to vLLM Voxtral over WebSocket

### DIFF
--- a/Transcriber/ASR/openai_streaming/index.js
+++ b/Transcriber/ASR/openai_streaming/index.js
@@ -64,6 +64,22 @@ const WATCHDOG_SLOW_RETRY_MS = parseInt(process.env.ASR_WATCHDOG_SLOW_RETRY_MS |
 const MUTE_WATCHDOG_SPEECH_MS = parseInt(process.env.ASR_MUTE_WATCHDOG_SPEECH_MS || '25000', 10);
 const MUTE_RMS_DBFS = parseFloat(process.env.ASR_MUTE_RMS_DBFS || '-45');
 
+// --- Silence-fill pacing (vLLM realtime) ---
+// The realtime server transcribes CONTINUOUSLY after the arming commit and
+// takes no mid-session commit, so it needs an uninterrupted audio stream. SRT
+// provides one by construction: GStreamer decodes the transport at 1x and emits
+// silent PCM through speech gaps, so transcribe() is called at a steady rate.
+// The WebSocket path has no such floor -- audio reaches the ASR only when the
+// client sends it, so a silent or bursty WS client starves the server and the
+// realtime generation stalls or wedges. This pump keeps the audio timeline at
+// wall-clock pace by appending digital silence whenever the real audio falls
+// more than ASR_SILENCE_KEEPALIVE_MS behind. When audio already flows at
+// real-time (SRT) the lag never crosses the threshold, so in steady state the
+// pump emits nothing and the SRT path is unchanged. 0 disables it.
+const SILENCE_KEEPALIVE_MS = parseInt(process.env.ASR_SILENCE_KEEPALIVE_MS || '200', 10);
+const PACING_INTERVAL_MS = 100;
+const SILENCE_FILL_MAX_MS = 2000; // cap one fill (bounds a stalled timer / very long gap)
+
 class OpenAIStreamingTranscriber extends EventEmitter {
     static ERROR_MAP = {
         0: 'NO_ERROR',
@@ -113,6 +129,16 @@ class OpenAIStreamingTranscriber extends EventEmitter {
         // mute session was force-restarted (separate from _watchdogRetries).
         this._speechMsSinceLastText = 0;
         this._muteResessions = 0;
+
+        // Silence-fill pacing state (see constant block). `_streamStartWall` is
+        // the wall-clock anchor set on the first real audio append; from then on
+        // `_audioMsAppended` (real audio + injected silence) is kept level with
+        // wall-clock. Null until the stream's first audio, so a session that
+        // never receives any audio injects nothing.
+        this._streamStartWall = null;
+        this._audioMsAppended = 0;
+        this._pacingTimer = null;
+        this._silenceKeepaliveMs = SILENCE_KEEPALIVE_MS;
 
         const config = channel.transcriberProfile.config;
 
@@ -195,6 +221,7 @@ class OpenAIStreamingTranscriber extends EventEmitter {
         this.emit('ready');
         this.startSegmentationTimer();
         this._startWatchdog();
+        this._startPacing();
     }
 
     _flushPreArmBuffer() {
@@ -332,6 +359,10 @@ class OpenAIStreamingTranscriber extends EventEmitter {
         this._draining = false;
         this._drainStartTime = 0;
         this._speechMsSinceLastText = 0;
+        // Reset the pacing clock; a reconnect re-anchors on its first audio.
+        this._streamStartWall = null;
+        this._audioMsAppended = 0;
+        this._stopPacing();
         this.emit('connecting');
 
         // Decrypt apiKey if present
@@ -723,6 +754,10 @@ class OpenAIStreamingTranscriber extends EventEmitter {
     }
 
     _sendAudio(buf) {
+        // Anchor the pacing clock on the stream's first real audio. Silence is
+        // only ever injected once this is set, so the first _sendAudio is always
+        // real audio and the anchor is honest.
+        if (this._streamStartWall === null) this._streamStartWall = Date.now();
         // Split large buffers into chunks of MAX_CHUNK_BYTES (200ms @ 16kHz mono 16-bit)
         const MAX_CHUNK_BYTES = 6400;
         let offset = 0;
@@ -733,6 +768,55 @@ class OpenAIStreamingTranscriber extends EventEmitter {
             this.ws.send(JSON.stringify(msg));
             offset += MAX_CHUNK_BYTES;
         }
+        // Advance the audio timeline (real audio and injected silence alike).
+        this._audioMsAppended += buf.length / PCM_BYTES_PER_MS;
+    }
+
+    // --- Silence-fill pacing (see constant block) ---
+
+    _startPacing() {
+        if (this._silenceKeepaliveMs <= 0) return;
+        this._stopPacing();
+        this._pacingTimer = setInterval(() => this._runPacingTick(Date.now()), PACING_INTERVAL_MS);
+        // Never keep the event loop alive just for the pump.
+        if (this._pacingTimer.unref) this._pacingTimer.unref();
+    }
+
+    _stopPacing() {
+        if (this._pacingTimer) {
+            clearInterval(this._pacingTimer);
+            this._pacingTimer = null;
+        }
+    }
+
+    /**
+     * One pacing tick. Extracted from the interval callback so it can be
+     * unit-tested with a controlled clock (same pattern as _runSegmentationTick).
+     * Appends just enough digital silence to bring the audio timeline back to
+     * wall-clock when real audio has fallen more than `_silenceKeepaliveMs`
+     * behind. Returns the ms of silence sent (0 when none is needed).
+     * @param {number} now - current timestamp in ms
+     */
+    _runPacingTick(now) {
+        if (this._silenceKeepaliveMs <= 0) return 0;
+        // No real audio yet: a session that never streams injects nothing.
+        if (this._streamStartWall === null) return 0;
+        if (!this._armed) return 0;
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return 0;
+
+        const lagMs = (now - this._streamStartWall) - this._audioMsAppended;
+        if (lagMs <= this._silenceKeepaliveMs) return 0; // real audio is keeping up
+
+        const fillMs = Math.min(Math.floor(lagMs), SILENCE_FILL_MAX_MS);
+        if (fillMs <= 0) return 0;
+        this._sendSilence(fillMs);
+        return fillMs;
+    }
+
+    _sendSilence(ms) {
+        // PCM S16LE zeros = digital silence. Routed through _sendAudio so it is
+        // chunked into the same 200ms appends and advances the audio clock.
+        this._sendAudio(Buffer.alloc(ms * PCM_BYTES_PER_MS));
     }
 
     _bufferPreArm(buf) {
@@ -757,6 +841,7 @@ class OpenAIStreamingTranscriber extends EventEmitter {
         this._connGeneration++;
 
         this._clearWatchdog();
+        this._stopPacing();
 
         // Clear all pending timers (setup delays, reconnection)
         for (const t of this._setupTimers) clearTimeout(t);

--- a/Transcriber/tests.js
+++ b/Transcriber/tests.js
@@ -25,6 +25,7 @@ require('./tests/test_asr_native_speaker.js');
 require('./tests/test_mqtt_payload_hardening.js');
 require('./tests/test_handshake.js');
 require('./tests/test_mute_watchdog.js');
+require('./tests/test_silence_keepalive.js');
 
 
 describe('CircularBuffer', () => {

--- a/Transcriber/tests/test_silence_keepalive.js
+++ b/Transcriber/tests/test_silence_keepalive.js
@@ -1,0 +1,176 @@
+const assert = require('assert');
+const { setupMocks, fromTranscriber } = require('./helpers/asr_mocks');
+
+// Silence-fill pacing suite.
+// The vLLM realtime server needs a CONTINUOUS audio stream. SRT provides it by
+// construction (GStreamer emits silent PCM at 1x through speech gaps); the
+// WebSocket path does not, so a silent/bursty WS client starves the server and
+// the realtime generation wedges. The pacing pump appends digital silence to
+// keep the audio timeline level with the wall clock. These tests pin the two
+// contracts that matter:
+//   1. NON-REGRESSION: when audio flows at real-time (SRT), the pump injects
+//      nothing -- the SRT byte stream is untouched.
+//   2. FIX: on a gap (WS silence), the pump fills exactly enough silence to
+//      bring the audio timeline back to the wall clock.
+
+// PCM S16LE 16kHz mono: 32 bytes/ms. Non-zero fill so real audio is trivially
+// distinguishable from injected (all-zero) silence.
+const PCM_BYTES_PER_MS = 32;
+function pcm(ms) { return Buffer.alloc(ms * PCM_BYTES_PER_MS, 1); }
+
+function appends(t) {
+    return t.ws.sentMessages
+        .map(m => JSON.parse(m))
+        .filter(m => m.type === 'input_audio_buffer.append');
+}
+function isSilent(appendMsg) {
+    return Buffer.from(appendMsg.audio, 'base64').every(b => b === 0);
+}
+function silenceAppends(t) {
+    return appends(t).filter(isSilent).length;
+}
+
+describe('OpenAIStreamingTranscriber silence-fill pacing', function () {
+    let OpenAIStreamingTranscriber;
+    let teardown;
+
+    before(function () {
+        teardown = setupMocks({ invalidate: [fromTranscriber('ASR/openai_streaming/index.js')] });
+        OpenAIStreamingTranscriber = require('../ASR/openai_streaming/index');
+    });
+
+    after(function () {
+        if (teardown) teardown();
+    });
+
+    function createTranscriber(configOverrides = {}) {
+        const session = { id: 'sess-1' };
+        const channel = {
+            id: 'chan-1',
+            transcriberProfile: {
+                config: {
+                    type: 'openai_streaming',
+                    endpoint: 'ws://localhost:8000',
+                    model: 'test-model',
+                    protocol: 'vllm',
+                    languages: [{ candidate: 'fr-FR' }],
+                    ...configOverrides
+                }
+            }
+        };
+        return new OpenAIStreamingTranscriber(session, channel);
+    }
+
+    // Arm the session (update + commit sent), then take over the pacing clock:
+    // stop the real interval so ticks are driven explicitly, and anchor the
+    // stream start at t=1000 with an empty audio timeline.
+    function armManual() {
+        const t = createTranscriber();
+        t.start();
+        t.ws.emit('message', JSON.stringify({ type: 'session.created', id: 'srv-1' }));
+        t._stopPacing();
+        t._streamStartWall = 1000;
+        t._audioMsAppended = 0;
+        return t;
+    }
+
+    // ------------------------------------------------------------------
+    // NON-REGRESSION: continuous real-time audio -> pump stays silent
+    // ------------------------------------------------------------------
+    it('injects no silence while audio flows at real-time (SRT path unchanged)', function () {
+        const t = armManual();
+
+        // 3 s of audio arriving in 100 ms slices, in lockstep with the clock.
+        for (let ms = 100; ms <= 3000; ms += 100) {
+            t.transcribe(pcm(100));                 // real audio: clock += 100
+            const filled = t._runPacingTick(1000 + ms); // wall clock advances 100 too
+            assert.strictEqual(filled, 0, `unexpected silence at ${ms}ms`);
+        }
+
+        assert.strictEqual(silenceAppends(t), 0, 'no silence append must be sent');
+        // Every append carried real (non-zero) audio.
+        assert.strictEqual(appends(t).length, 30);
+        t.stop();
+    });
+
+    it('injects nothing when audio runs AHEAD of the wall clock (burst)', function () {
+        const t = armManual();
+        t.transcribe(pcm(2000));                    // 2 s delivered in a burst
+        const filled = t._runPacingTick(1500);      // only 500 ms of wall clock elapsed
+        assert.strictEqual(filled, 0);
+        assert.strictEqual(silenceAppends(t), 0);
+        t.stop();
+    });
+
+    // ------------------------------------------------------------------
+    // FIX: a gap in the client audio is filled with silence up to wall-clock
+    // ------------------------------------------------------------------
+    it('fills silence to the wall clock on a client gap', function () {
+        const t = armManual();
+        t.transcribe(pcm(200));                     // 200 ms real audio, clock = 200
+
+        // 1 s of client silence: wall clock is now 1000 + 200 + 1000 = 2200.
+        const filled = t._runPacingTick(2200);
+
+        assert.strictEqual(filled, 1000, 'should fill exactly the 1000ms deficit');
+        // Audio timeline is back level with the wall clock (200 real + 1000 fill).
+        assert.strictEqual(t._audioMsAppended, 1200);
+        assert.strictEqual(t._audioMsAppended, 2200 - t._streamStartWall);
+        // The fill was digital silence, chunked into 200ms appends (1000/200 = 5).
+        assert.strictEqual(silenceAppends(t), 5);
+        t.stop();
+    });
+
+    it('stays within the keepalive grace without filling (tolerates jitter)', function () {
+        const t = armManual();
+        t.transcribe(pcm(200));                     // clock = 200
+        // Deficit of exactly the grace threshold must NOT trigger a fill.
+        const filled = t._runPacingTick(1000 + 200 + t._silenceKeepaliveMs);
+        assert.strictEqual(filled, 0);
+        assert.strictEqual(silenceAppends(t), 0);
+        t.stop();
+    });
+
+    it('caps a single fill at SILENCE_FILL_MAX_MS on a very long gap', function () {
+        const t = armManual();
+        t.transcribe(pcm(100));                     // clock = 100
+        // 60 s gap: one tick must not inject the whole minute at once.
+        const filled = t._runPacingTick(1000 + 60000);
+        assert.strictEqual(filled, 2000, 'single fill capped at 2000ms');
+        t.stop();
+    });
+
+    // ------------------------------------------------------------------
+    // Guards
+    // ------------------------------------------------------------------
+    it('injects nothing before any real audio (session that never streams)', function () {
+        const t = createTranscriber();
+        t.start();
+        t.ws.emit('message', JSON.stringify({ type: 'session.created', id: 'srv-1' }));
+        t._stopPacing();
+        // No transcribe() call: _streamStartWall stays null.
+        assert.strictEqual(t._streamStartWall, null);
+        assert.strictEqual(t._runPacingTick(1e9), 0);
+        assert.strictEqual(appends(t).length, 0);
+        t.stop();
+    });
+
+    it('is a no-op when disabled (ASR_SILENCE_KEEPALIVE_MS=0)', function () {
+        const t = armManual();
+        t._silenceKeepaliveMs = 0;                  // simulate the env kill switch
+        t.transcribe(pcm(100));
+        const filled = t._runPacingTick(1000 + 60000); // huge gap
+        assert.strictEqual(filled, 0);
+        assert.strictEqual(silenceAppends(t), 0);
+        t.stop();
+    });
+
+    it('does not resume pacing after stop()', function () {
+        const t = armManual();
+        t.transcribe(pcm(100));
+        t.stop();
+        // ws is closed by stop(); a tick must be inert.
+        const filled = t._runPacingTick(1000 + 60000);
+        assert.strictEqual(filled, 0);
+    });
+});


### PR DESCRIPTION
The vLLM realtime server transcribes continuously after arming and takes no mid-session commit, so it needs an uninterrupted audio stream. SRT provides one (GStreamer emits silent PCM at 1x through speech gaps); the WebSocket path does not, so a silent/bursty client starves the server and the realtime generation wedges, blocking transcription.

Adds a silence-fill pacing pump in the openai_streaming ASR: anchored on the first real audio, it appends digital silence whenever the audio timeline falls more than ASR_SILENCE_KEEPALIVE_MS (default 200ms) behind the wall clock. No-op when audio flows continuously (SRT path unchanged); never injects before the first audio. Configurable, disable with ASR_SILENCE_KEEPALIVE_MS=0.

Covered by tests/test_silence_keepalive.js (8 cases incl. SRT non-regression). Full suite: 331 passing.